### PR TITLE
refactor: centralize MessageSender and ResilientRequestMiddleware

### DIFF
--- a/derp/middlewares/api_resilient.py
+++ b/derp/middlewares/api_resilient.py
@@ -1,6 +1,7 @@
 """Session middleware for resilient Bot API requests.
 
-Adds automatic retry logic for transient Telegram API errors like flood control.
+Adds automatic retry logic for transient Telegram API errors like flood control
+and HTML parse failures.
 """
 
 from __future__ import annotations
@@ -11,8 +12,43 @@ from typing import Any
 import logfire
 from aiogram import Bot
 from aiogram.client.session.middlewares.base import BaseRequestMiddleware
-from aiogram.exceptions import TelegramRetryAfter
-from aiogram.methods import TelegramMethod
+from aiogram.exceptions import TelegramBadRequest, TelegramRetryAfter
+from aiogram.methods import SendMediaGroup, TelegramMethod
+
+from derp.common.sanitize import strip_html_tags
+
+
+def _create_plain_text_method(
+    method: TelegramMethod[Any],
+) -> TelegramMethod[Any] | None:
+    """Create a copy of the method with parse_mode=None and stripped text/caption.
+
+    Returns None if the method doesn't have text/caption content.
+    """
+    # Handle SendMediaGroup specially (has list of media items)
+    if isinstance(method, SendMediaGroup):
+        new_media = [
+            item.model_copy(
+                update={"caption": strip_html_tags(caption), "parse_mode": None}
+            )
+            if (caption := getattr(item, "caption", None))
+            else item
+            for item in method.media
+        ]
+        return method.model_copy(update={"media": new_media})
+
+    # Handle methods with text or caption field (mutually exclusive)
+    if text := getattr(method, "text", None):
+        return method.model_copy(
+            update={"text": strip_html_tags(text), "parse_mode": None}
+        )
+
+    if caption := getattr(method, "caption", None):
+        return method.model_copy(
+            update={"caption": strip_html_tags(caption), "parse_mode": None}
+        )
+
+    return None
 
 
 class ResilientRequestMiddleware(BaseRequestMiddleware):
@@ -20,6 +56,7 @@ class ResilientRequestMiddleware(BaseRequestMiddleware):
 
     Handles:
     - TelegramRetryAfter (flood control): waits and retries up to max_retries times
+    - TelegramBadRequest with "can't parse entities": retries with plain text
     """
 
     def __init__(self, max_retries: int = 3):
@@ -32,7 +69,9 @@ class ResilientRequestMiddleware(BaseRequestMiddleware):
         bot: Bot,
         method: TelegramMethod[Any],
     ) -> Any:
-        for attempt in range(1, self.max_retries):
+        last_exception: Exception | None = None
+
+        for attempt in range(1, self.max_retries + 1):
             try:
                 return await make_request(bot, method)
             except TelegramRetryAfter as exc:
@@ -47,3 +86,25 @@ class ResilientRequestMiddleware(BaseRequestMiddleware):
                     max_retries=self.max_retries,
                 )
                 await asyncio.sleep(exc.retry_after)
+                last_exception = exc
+
+            except TelegramBadRequest as exc:
+                if "can't parse entities" not in exc.message.lower():
+                    raise
+
+                # Try with plain text fallback
+                plain_method = _create_plain_text_method(method)
+                if plain_method is None:
+                    raise
+
+                logfire.warning(
+                    "html_parse_failed_fallback",
+                    method=type(method).__name__,
+                    _exc_info=True,
+                )
+                return await make_request(bot, plain_method)
+
+        # Should not reach here, but satisfy type checker
+        if last_exception:
+            raise last_exception
+        raise RuntimeError("Unexpected state in ResilientRequestMiddleware")

--- a/derp/tools/image_gen.py
+++ b/derp/tools/image_gen.py
@@ -18,12 +18,6 @@ from derp.llm.deps import AgentDeps
 from derp.tools.wrapper import credit_aware_tool
 
 
-def _to_filename(mime: str, idx: int = 1) -> str:
-    """Generate a filename based on mime type."""
-    ext = "png" if "png" in mime else "jpg"
-    return f"generated_{idx}.{ext}"
-
-
 @credit_aware_tool("image_generate")
 async def generate_image(
     ctx: RunContext[AgentDeps],
@@ -66,13 +60,8 @@ async def generate_image(
 
         # Handle the output
         if isinstance(output, BinaryImage):
-            caption = f"🎨 {prompt}"
             sender = MessageSender.from_message(deps.message)
-            await sender.reply_photo(
-                output.data,
-                caption=caption,
-                filename=_to_filename(output.media_type),
-            )
+            await sender.compose().text(f"🎨 {prompt}").image(output).reply()
 
             logfire.info(
                 "image_generated_and_sent",
@@ -159,13 +148,8 @@ async def edit_image(
 
         # Handle the output
         if isinstance(output, BinaryImage):
-            caption = f"✏️ {edit_prompt}"
             sender = MessageSender.from_message(message)
-            await sender.reply_photo(
-                output.data,
-                caption=caption,
-                filename=_to_filename(output.media_type),
-            )
+            await sender.compose().text(f"✏️ {edit_prompt}").image(output).reply()
 
             logfire.info(
                 "image_edited_and_sent",

--- a/derp/tools/tts.py
+++ b/derp/tools/tts.py
@@ -21,14 +21,6 @@ from derp.tools.wrapper import credit_aware_tool
 TTS_MODEL = "gemini-2.5-pro-preview-tts"
 
 
-def _filename_for_mime(mime: str) -> str:
-    if "mpeg" in mime or "mp3" in mime:
-        return "tts.mp3"
-    if "ogg" in mime:
-        return "tts.ogg"
-    return "tts.wav"
-
-
 async def generate_and_send_tts(
     deps: AgentDeps,
     *,
@@ -61,11 +53,7 @@ async def generate_and_send_tts(
         raise RuntimeError("No audio returned from TTS model.")
 
     sender = MessageSender.from_message(deps.message)
-    await sender.reply_audio(
-        audio_bytes,
-        caption=text,
-        filename=_filename_for_mime(audio_mime),
-    )
+    await sender.compose().text(text).audio(audio_bytes, audio_mime).reply()
 
     logfire.info(
         "tts_done",

--- a/derp/tools/video_gen.py
+++ b/derp/tools/video_gen.py
@@ -121,7 +121,7 @@ async def generate_and_send_video(
     video_bytes = await _download_video_to_bytes(client, video_obj)
 
     sender = MessageSender.from_message(deps.message)
-    await sender.reply_video(video_bytes, caption=prompt)
+    await sender.compose().text(prompt).video(video_bytes).reply()
 
     logfire.info(
         "veo_generate_done",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -946,10 +946,6 @@ def mock_sender(make_message):
         sender.reply = AsyncMock(return_value=MagicMock())
         sender.edit = AsyncMock(return_value=MagicMock())
         sender.edit_inline = AsyncMock(return_value=True)
-        sender.send_photo = AsyncMock(return_value=MagicMock())
-        sender.reply_photo = AsyncMock(return_value=MagicMock())
-        sender.send_media_group = AsyncMock(return_value=[MagicMock()])
-        sender.send_with_media = AsyncMock(return_value=MagicMock())
 
         for key, value in kwargs.items():
             setattr(sender, key, value)

--- a/tests/test_handlers_image.py
+++ b/tests/test_handlers_image.py
@@ -3,137 +3,48 @@
 from unittest.mock import MagicMock
 
 import pytest
-from pydantic_ai import BinaryImage
 
 from derp.credits.models import ModelTier
 from derp.handlers.image import (
-    _send_image_result,
-    _send_multiple_images,
-    _to_filename,
+    handle_edit,
     handle_imagine,
 )
-
-
-class TestHelperFunctions:
-    """Tests for helper functions."""
-
-    def test_to_filename_jpeg(self):
-        """Test filename generation for JPEG."""
-        assert _to_filename("image/jpeg", 1) == "generated_1.jpg"
-        assert _to_filename("image/jpg", 2) == "generated_2.jpg"
-
-    def test_to_filename_png(self):
-        """Test filename generation for PNG."""
-        assert _to_filename("image/png", 1) == "generated_1.png"
-
-    def test_to_filename_other(self):
-        """Test filename generation for other types defaults to png."""
-        assert _to_filename("image/webp", 1) == "generated_1.png"
-
-
-class TestSendImageResult:
-    """Tests for _send_image_result."""
-
-    @pytest.mark.asyncio
-    async def test_sends_text_response(self, make_message):
-        """Test sending text response when model returns string."""
-        message = make_message(text="/imagine")
-
-        await _send_image_result(message, "Sorry, I can't generate that.")
-
-        message.reply.assert_awaited_once()
-        assert "Sorry" in message.reply.call_args[0][0]
-
-    @pytest.mark.asyncio
-    async def test_sends_empty_response(self, make_message):
-        """Test sending response for empty string."""
-        message = make_message(text="/imagine")
-
-        await _send_image_result(message, "")
-
-        message.reply.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_sends_image_response(self, make_message):
-        """Test sending binary image response."""
-        message = make_message(text="/imagine")
-
-        image = BinaryImage(data=b"\x89PNG...", media_type="image/png")
-
-        await _send_image_result(message, image)
-
-        # Uses bot.send_photo via MessageSender
-        message.bot.send_photo.assert_awaited_once()
-
-
-class TestSendMultipleImages:
-    """Tests for _send_multiple_images."""
-
-    @pytest.mark.asyncio
-    async def test_sends_empty_list(self, make_message):
-        """Test sending empty list shows error."""
-        message = make_message(text="/imagine")
-
-        await _send_multiple_images(message, [])
-
-        message.reply.assert_awaited_once()
-        assert "No images" in message.reply.call_args[0][0]
-
-    @pytest.mark.asyncio
-    async def test_sends_single_image(self, make_message):
-        """Test single image delegates to _send_image_result."""
-        message = make_message(text="/imagine")
-        image = BinaryImage(data=b"\x89PNG...", media_type="image/png")
-
-        await _send_multiple_images(message, [image])
-
-        # Uses bot.send_photo via MessageSender
-        message.bot.send_photo.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_sends_multiple_images_as_group(self, make_message):
-        """Test multiple images sent as media group."""
-        message = make_message(text="/imagine")
-
-        images = [
-            BinaryImage(data=b"\x89PNG1", media_type="image/png"),
-            BinaryImage(data=b"\x89PNG2", media_type="image/png"),
-        ]
-
-        await _send_multiple_images(message, images)
-
-        # Uses bot.send_media_group via MessageSender
-        message.bot.send_media_group.assert_awaited_once()
 
 
 class TestHandleImagine:
     """Tests for /imagine command handler."""
 
     @pytest.mark.asyncio
-    async def test_missing_prompt(self, make_message, mock_credit_service_factory):
+    async def test_missing_prompt(
+        self, make_message, mock_credit_service_factory, mock_sender
+    ):
         """Test /imagine without prompt shows usage."""
         message = make_message(text="/imagine")
 
         meta = MagicMock()
         meta.target_text = ""
         service = mock_credit_service_factory()
+        sender = mock_sender(message)
 
-        await handle_imagine(message, meta, service, None, None)
+        await handle_imagine(message, meta, sender, service, None, None)
 
         message.reply.assert_awaited_once()
         assert "Usage" in message.reply.call_args[0][0]
 
     @pytest.mark.asyncio
-    async def test_no_user(self, make_message, mock_credit_service_factory):
+    async def test_no_user(
+        self, make_message, mock_credit_service_factory, mock_sender
+    ):
         """Test /imagine without user shows error."""
         message = make_message(text="/imagine a cat")
 
         meta = MagicMock()
         meta.target_text = "a cat"
         service = mock_credit_service_factory()
+        sender = mock_sender(message)
 
         # user_model=None, chat_model provided
-        await handle_imagine(message, meta, service, None, MagicMock())
+        await handle_imagine(message, meta, sender, service, None, MagicMock())
 
         message.reply.assert_awaited_once()
         assert "Could not verify" in message.reply.call_args[0][0]
@@ -146,6 +57,7 @@ class TestHandleImagine:
         mock_chat_model,
         mock_credit_service_factory,
         make_credit_check_result,
+        mock_sender,
     ):
         """Test /imagine rejected when no credits."""
         message = make_message(text="/imagine a cat")
@@ -155,6 +67,7 @@ class TestHandleImagine:
 
         user = mock_user_model()
         chat = mock_chat_model()
+        sender = mock_sender(message)
 
         check_result = make_credit_check_result(
             allowed=False,
@@ -164,7 +77,30 @@ class TestHandleImagine:
         )
         service = mock_credit_service_factory(check_result=check_result)
 
-        await handle_imagine(message, meta, service, user_model=user, chat_model=chat)
+        await handle_imagine(
+            message, meta, sender, service, user_model=user, chat_model=chat
+        )
 
         message.reply.assert_awaited_once()
         assert "Not enough credits" in message.reply.call_args[0][0]
+
+
+class TestHandleEdit:
+    """Tests for /edit command handler."""
+
+    @pytest.mark.asyncio
+    async def test_missing_prompt(
+        self, make_message, mock_credit_service_factory, mock_sender
+    ):
+        """Test /edit without prompt shows usage."""
+        message = make_message(text="/edit")
+
+        meta = MagicMock()
+        meta.target_text = ""
+        service = mock_credit_service_factory()
+        sender = mock_sender(message)
+
+        await handle_edit(message, meta, sender, service, None, None)
+
+        message.reply.assert_awaited_once()
+        assert "Reply to an image" in message.reply.call_args[0][0]

--- a/tests/test_middlewares_api_resilient.py
+++ b/tests/test_middlewares_api_resilient.py
@@ -1,0 +1,240 @@
+"""Tests for ResilientRequestMiddleware."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiogram import Bot
+from aiogram.exceptions import TelegramBadRequest, TelegramRetryAfter
+from aiogram.methods import SendMediaGroup, SendMessage, SendPhoto
+from aiogram.types import InputMediaPhoto
+
+from derp.common.sanitize import strip_html_tags
+from derp.middlewares.api_resilient import (
+    ResilientRequestMiddleware,
+    _create_plain_text_method,
+)
+
+
+class TestStripHtmlTags:
+    """Tests for strip_html_tags helper (from sanitize module)."""
+
+    def test_strips_bold(self):
+        assert strip_html_tags("<b>bold</b>") == "bold"
+
+    def test_strips_italic(self):
+        assert strip_html_tags("<i>italic</i>") == "italic"
+
+    def test_strips_multiple_tags(self):
+        assert strip_html_tags("<b>bold</b> and <i>italic</i>") == "bold and italic"
+
+    def test_preserves_plain_text(self):
+        assert strip_html_tags("plain text") == "plain text"
+
+    def test_handles_empty_string(self):
+        assert strip_html_tags("") == ""
+
+
+class TestCreatePlainTextMethod:
+    """Tests for _create_plain_text_method."""
+
+    def test_send_message_strips_html(self):
+        method = SendMessage(chat_id=123, text="<b>bold</b> text", parse_mode="HTML")
+        plain = _create_plain_text_method(method)
+
+        assert plain is not None
+        assert plain.text == "bold text"
+        assert plain.parse_mode is None
+
+    def test_send_photo_strips_caption(self):
+        method = SendPhoto(
+            chat_id=123,
+            photo="file_id",
+            caption="<b>bold</b> caption",
+            parse_mode="HTML",
+        )
+        plain = _create_plain_text_method(method)
+
+        assert plain is not None
+        assert plain.caption == "bold caption"
+        assert plain.parse_mode is None
+
+    def test_returns_none_for_unsupported_method(self):
+        # Use a method that doesn't have text/caption
+        method = MagicMock(spec=[])  # Empty spec means no attributes
+        result = _create_plain_text_method(method)
+        assert result is None
+
+    def test_returns_none_for_empty_text(self):
+        method = SendMessage(chat_id=123, text="", parse_mode="HTML")
+        result = _create_plain_text_method(method)
+        assert result is None
+
+    def test_send_media_group_strips_captions(self):
+        """SendMediaGroup should strip HTML from all media captions."""
+        method = SendMediaGroup(
+            chat_id=123,
+            media=[
+                InputMediaPhoto(media="file_id_1", caption="<b>photo 1</b>"),
+                InputMediaPhoto(media="file_id_2", caption="<i>photo 2</i>"),
+                InputMediaPhoto(media="file_id_3"),  # No caption
+            ],
+        )
+        plain = _create_plain_text_method(method)
+
+        assert plain is not None
+        assert plain.media[0].caption == "photo 1"
+        assert plain.media[0].parse_mode is None
+        assert plain.media[1].caption == "photo 2"
+        assert plain.media[1].parse_mode is None
+        # Third item should be unchanged (no caption)
+        assert plain.media[2].caption is None
+
+
+class TestResilientMiddleware:
+    """Tests for ResilientRequestMiddleware."""
+
+    @pytest.fixture
+    def middleware(self):
+        return ResilientRequestMiddleware(max_retries=3)
+
+    @pytest.fixture
+    def mock_bot(self):
+        return MagicMock(spec=Bot)
+
+    @pytest.mark.asyncio
+    async def test_passes_through_on_success(self, middleware, mock_bot):
+        """Successful requests should pass through unchanged."""
+        method = SendMessage(chat_id=123, text="hello")
+        make_request = AsyncMock(return_value=MagicMock())
+
+        result = await middleware(make_request, mock_bot, method)
+
+        make_request.assert_awaited_once_with(mock_bot, method)
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_html_fallback_on_parse_error(self, middleware, mock_bot):
+        """Should retry with plain text on HTML parse error."""
+        method = SendMessage(chat_id=123, text="<b>bold</b>", parse_mode="HTML")
+
+        make_request = AsyncMock(
+            side_effect=[
+                TelegramBadRequest(
+                    method=MagicMock(),
+                    message="Bad Request: can't parse entities",
+                ),
+                MagicMock(),  # Success on retry
+            ]
+        )
+
+        result = await middleware(make_request, mock_bot, method)
+
+        assert make_request.await_count == 2
+        # Second call should have stripped HTML
+        second_call = make_request.call_args_list[1]
+        modified_method = second_call.args[1]
+        assert modified_method.text == "bold"
+        assert modified_method.parse_mode is None
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_reraises_non_parse_errors(self, middleware, mock_bot):
+        """Non-parse errors should be re-raised."""
+        method = SendMessage(chat_id=123, text="hello")
+
+        make_request = AsyncMock(
+            side_effect=TelegramBadRequest(
+                method=MagicMock(),
+                message="Bad Request: chat not found",
+            )
+        )
+
+        with pytest.raises(TelegramBadRequest):
+            await middleware(make_request, mock_bot, method)
+
+    @pytest.mark.asyncio
+    async def test_retry_after_waits_and_retries(self, middleware, mock_bot):
+        """Should wait and retry on rate limit errors."""
+        method = SendMessage(chat_id=123, text="hello")
+
+        make_request = AsyncMock(
+            side_effect=[
+                TelegramRetryAfter(
+                    method=MagicMock(),
+                    message="Flood control",
+                    retry_after=0.01,  # 10ms for fast test
+                ),
+                MagicMock(),  # Success on retry
+            ]
+        )
+
+        result = await middleware(make_request, mock_bot, method)
+
+        assert make_request.await_count == 2
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_retry_after_exhausts_max_retries(self, middleware, mock_bot):
+        """Should raise after exhausting max retries on rate limit."""
+        method = SendMessage(chat_id=123, text="hello")
+
+        # Always return retry after error
+        make_request = AsyncMock(
+            side_effect=TelegramRetryAfter(
+                method=MagicMock(),
+                message="Flood control",
+                retry_after=0.001,
+            )
+        )
+
+        with pytest.raises(TelegramRetryAfter):
+            await middleware(make_request, mock_bot, method)
+
+        assert make_request.await_count == 3  # max_retries
+
+    @pytest.mark.asyncio
+    async def test_html_error_on_unsupported_method_reraises(
+        self, middleware, mock_bot
+    ):
+        """HTML parse error on method without text/caption should re-raise."""
+        # Use a mock method with no text or caption
+        method = MagicMock(spec=[])
+
+        make_request = AsyncMock(
+            side_effect=TelegramBadRequest(
+                method=MagicMock(),
+                message="Bad Request: can't parse entities",
+            )
+        )
+
+        with pytest.raises(TelegramBadRequest):
+            await middleware(make_request, mock_bot, method)
+
+    @pytest.mark.asyncio
+    async def test_html_fallback_on_media_group(self, middleware, mock_bot):
+        """Should strip HTML from media group captions on parse error."""
+        method = SendMediaGroup(
+            chat_id=123,
+            media=[
+                InputMediaPhoto(media="file_id", caption="<b>test</b>"),
+            ],
+        )
+
+        make_request = AsyncMock(
+            side_effect=[
+                TelegramBadRequest(
+                    method=MagicMock(),
+                    message="Bad Request: can't parse entities",
+                ),
+                MagicMock(),  # Success on retry
+            ]
+        )
+
+        result = await middleware(make_request, mock_bot, method)
+
+        assert make_request.await_count == 2
+        # Second call should have stripped HTML
+        second_call = make_request.call_args_list[1]
+        modified_method = second_call.args[1]
+        assert modified_method.media[0].caption == "test"
+        assert result is not None


### PR DESCRIPTION
## Summary

Refactors message sending infrastructure and centralizes error handling in middleware.

### Key Changes

**MessageSender & ContentBuilder**
- Introduce `ContentBuilder` fluent API for composing mixed-content messages
- Remove redundant methods (`reply_images`, `send_photo`, `send_video`, etc.)
- Reduces `sender.py` from ~1590 to ~866 lines

**ResilientRequestMiddleware**
- Move HTML parse error fallback from individual sender methods to session middleware
- Use `hasattr`/`getattr` for duck typing instead of hardcoded field maps
- Add `_exc_info=True` to warning logs for proper traceback capture
- Handle `SendMediaGroup` caption stripping

**AGENTS.md Updates**
- Add coding style guidance (walrus operator, concise idioms)
- Add logging best practices (`_exc_info=True` for warnings/errors in except blocks)
- Add testing guideline about reusable fixtures

### Testing
- Add comprehensive tests for `api_resilient` middleware (93% coverage)
- 378 tests passing