### PR TITLE
feat: send TTS as voice messages with ffmpeg conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,11 @@ COPY --from=builder --chown=app:app /app/derp /app/derp
 COPY --from=builder --chown=app:app /app/alembic.ini /app/alembic.ini
 COPY --from=builder --chown=app:app /app/migrations /app/migrations
 
+# Install ffmpeg for audio conversion (TTS voice messages)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ffmpeg && \
+    rm -rf /var/lib/apt/lists/*
+
 # Create non-root user for security
 RUN groupadd --gid=1000 app && \
     useradd --uid=1000 --gid=app --shell=/bin/bash --create-home app

--- a/derp/common/audio.py
+++ b/derp/common/audio.py
@@ -1,0 +1,103 @@
+"""Audio conversion utilities using ffmpeg.
+
+Provides async audio format conversion for TTS voice messages.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import logfire
+
+
+class AudioConversionError(Exception):
+    """Raised when audio conversion fails."""
+
+
+async def convert_to_ogg_opus(
+    audio_bytes: bytes,
+    *,
+    input_format: str = "wav",
+    sample_rate: int | None = None,
+    channels: int = 1,
+) -> bytes:
+    """Convert audio bytes to OGG/Opus format using ffmpeg.
+
+    Args:
+        audio_bytes: Raw audio data to convert.
+        input_format: Input format hint for ffmpeg (e.g., "wav", "s16le" for raw PCM).
+        sample_rate: Sample rate in Hz. Required for raw PCM formats like "s16le".
+        channels: Number of audio channels (default: 1 for mono).
+
+    Returns:
+        Audio data encoded as OGG/Opus.
+
+    Raises:
+        AudioConversionError: If ffmpeg fails or is not available.
+    """
+    # Build ffmpeg command
+    # -i pipe:0  = read from stdin
+    # -f ogg     = output format
+    # -c:a libopus = Opus codec
+    # pipe:1     = write to stdout
+    cmd = ["ffmpeg", "-hide_banner", "-loglevel", "error"]
+
+    # Input format options
+    if input_format == "s16le":
+        # Raw PCM needs explicit format specification
+        if sample_rate is None:
+            raise AudioConversionError("sample_rate required for raw PCM input")
+        cmd.extend(["-f", "s16le", "-ar", str(sample_rate), "-ac", str(channels)])
+
+    cmd.extend(["-i", "pipe:0"])
+
+    # Output format options
+    cmd.extend(
+        [
+            "-c:a",
+            "libopus",
+            "-b:a",
+            "48k",  # Good quality for voice
+            "-vbr",
+            "on",
+            "-application",
+            "voip",  # Optimized for speech
+            "-f",
+            "ogg",
+            "pipe:1",
+        ]
+    )
+
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        stdout, stderr = await process.communicate(input=audio_bytes)
+
+        if process.returncode != 0:
+            error_msg = stderr.decode(errors="replace").strip()
+            logfire.warning(
+                "ffmpeg_conversion_failed",
+                returncode=process.returncode,
+                stderr=error_msg[:500],
+                input_size=len(audio_bytes),
+            )
+            raise AudioConversionError(f"ffmpeg failed: {error_msg}")
+
+        logfire.debug(
+            "audio_converted",
+            input_format=input_format,
+            input_size=len(audio_bytes),
+            output_size=len(stdout),
+        )
+
+        return stdout
+
+    except FileNotFoundError as e:
+        raise AudioConversionError("ffmpeg not found - is it installed?") from e
+    except TimeoutError as e:
+        raise AudioConversionError("ffmpeg conversion timed out") from e

--- a/derp/tools/gemini_tts.py
+++ b/derp/tools/gemini_tts.py
@@ -13,12 +13,16 @@ from google import genai
 from google.genai import types
 from pydantic_ai import RunContext
 
+from derp.common.audio import convert_to_ogg_opus
 from derp.common.sender import MessageSender
 from derp.config import settings
 from derp.llm.deps import AgentDeps
 from derp.tools.wrapper import credit_aware_tool
 
 TTS_MODEL = "gemini-2.5-flash-preview-tts"
+
+# Gemini TTS returns raw 16-bit PCM at 24kHz
+GEMINI_TTS_SAMPLE_RATE = 24000
 
 
 async def generate_and_send_tts(
@@ -52,14 +56,28 @@ async def generate_and_send_tts(
     if not audio_bytes or not audio_mime:
         raise RuntimeError("No audio returned from TTS model.")
 
+    # Convert to OGG/Opus for Telegram voice messages
+    # Gemini returns audio/L16;rate=24000 (raw 16-bit PCM)
+    mime_lower = audio_mime.lower()
+    if "l16" in mime_lower or "pcm" in mime_lower:
+        ogg_bytes = await convert_to_ogg_opus(
+            audio_bytes,
+            input_format="s16le",
+            sample_rate=GEMINI_TTS_SAMPLE_RATE,
+        )
+    else:
+        # Fallback: assume WAV container
+        ogg_bytes = await convert_to_ogg_opus(audio_bytes, input_format="wav")
+
     sender = MessageSender.from_message(deps.message)
-    await sender.compose().text(text).audio(audio_bytes, audio_mime).reply()
+    await sender.compose().voice(ogg_bytes).reply()
 
     logfire.info(
         "tts_done",
         model=tts_model,
-        bytes=len(audio_bytes),
-        mime=audio_mime,
+        input_bytes=len(audio_bytes),
+        output_bytes=len(ogg_bytes),
+        input_mime=audio_mime,
         chat_id=deps.chat_id,
     )
 

--- a/derp/tools/tts.py
+++ b/derp/tools/tts.py
@@ -1,81 +1,14 @@
 """Text-to-speech tool for Pydantic-AI agents.
 
-Uses google-genai SDK for audio output.
-
-Models: https://ai.google.dev/gemini-api/docs/models.md.txt
-Pricing: https://ai.google.dev/gemini-api/docs/pricing.md.txt
+DEPRECATED: This module is kept for backwards compatibility.
+Use derp.tools.gemini_tts instead.
 """
 
-from __future__ import annotations
+from derp.tools.gemini_tts import (
+    GEMINI_TTS_SAMPLE_RATE,
+    TTS_MODEL,
+    generate_and_send_tts,
+    voice_tts,
+)
 
-import logfire
-from google import genai
-from google.genai import types
-from pydantic_ai import RunContext
-
-from derp.common.sender import MessageSender
-from derp.config import settings
-from derp.llm.deps import AgentDeps
-from derp.tools.wrapper import credit_aware_tool
-
-TTS_MODEL = "gemini-2.5-flash-preview-tts"
-
-
-async def generate_and_send_tts(
-    deps: AgentDeps,
-    *,
-    text: str,
-    model: str | None = None,
-) -> None:
-    tts_model = model or TTS_MODEL
-
-    client = genai.Client(api_key=settings.google_api_paid_key)
-    logfire.info("tts_start", model=tts_model, chars=len(text), chat_id=deps.chat_id)
-
-    # Use async API
-    response = await client.aio.models.generate_content(
-        model=tts_model,
-        contents=text,
-        config=types.GenerateContentConfig(response_modalities=["AUDIO"]),
-    )
-
-    audio_bytes: bytes | None = None
-    audio_mime: str | None = None
-
-    if response.parts:
-        for part in response.parts:
-            if part.inline_data:
-                audio_bytes = part.inline_data.data
-                audio_mime = part.inline_data.mime_type
-                break
-
-    if not audio_bytes or not audio_mime:
-        raise RuntimeError("No audio returned from TTS model.")
-
-    sender = MessageSender.from_message(deps.message)
-    await sender.compose().text(text).audio(audio_bytes, audio_mime).reply()
-
-    logfire.info(
-        "tts_done",
-        model=tts_model,
-        bytes=len(audio_bytes),
-        mime=audio_mime,
-        chat_id=deps.chat_id,
-    )
-
-
-@credit_aware_tool("voice_tts")
-async def voice_tts(
-    ctx: RunContext[AgentDeps],
-    text: str,
-) -> str:
-    """Generate speech audio from text and send it to the chat.
-
-    Use this tool when the user asks you to say something out loud,
-    read text aloud, or create a voice message.
-
-    Args:
-        text: The text to convert to speech. Can be any length.
-    """
-    await generate_and_send_tts(ctx.deps, text=text)
-    return "[Sent directly to chat. Do not output anything else unless the user asked a follow-up question.]"
+__all__ = ["TTS_MODEL", "GEMINI_TTS_SAMPLE_RATE", "generate_and_send_tts", "voice_tts"]

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,153 @@
+"""Tests for audio conversion utilities.
+
+These tests require ffmpeg to be installed. They are skipped if ffmpeg is not available.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shutil
+import struct
+from typing import TYPE_CHECKING
+
+import pytest
+
+from derp.common.audio import AudioConversionError, convert_to_ogg_opus
+
+if TYPE_CHECKING:
+    pass
+
+# Check if ffmpeg is available
+FFMPEG_AVAILABLE = shutil.which("ffmpeg") is not None
+
+
+def create_wav_header(
+    num_samples: int,
+    sample_rate: int = 24000,
+    channels: int = 1,
+    bits_per_sample: int = 16,
+) -> bytes:
+    """Create a valid WAV file header."""
+    data_size = num_samples * channels * (bits_per_sample // 8)
+    file_size = 36 + data_size  # 44 - 8 = 36
+
+    header = struct.pack(
+        "<4sI4s4sIHHIIHH4sI",
+        b"RIFF",
+        file_size,
+        b"WAVE",
+        b"fmt ",
+        16,  # PCM chunk size
+        1,  # Audio format (PCM)
+        channels,
+        sample_rate,
+        sample_rate * channels * (bits_per_sample // 8),  # Byte rate
+        channels * (bits_per_sample // 8),  # Block align
+        bits_per_sample,
+        b"data",
+        data_size,
+    )
+    return header
+
+
+def generate_sine_wave_pcm(
+    duration_ms: int = 100,
+    frequency: int = 440,
+    sample_rate: int = 24000,
+    amplitude: int = 16000,
+) -> bytes:
+    """Generate raw 16-bit PCM sine wave data."""
+    import math
+
+    num_samples = int(sample_rate * duration_ms / 1000)
+    samples = []
+    for i in range(num_samples):
+        t = i / sample_rate
+        value = int(amplitude * math.sin(2 * math.pi * frequency * t))
+        samples.append(struct.pack("<h", value))
+    return b"".join(samples)
+
+
+@pytest.fixture
+def wav_audio() -> bytes:
+    """Generate a short WAV file with a sine wave."""
+    pcm_data = generate_sine_wave_pcm(duration_ms=100)
+    header = create_wav_header(len(pcm_data) // 2)  # 2 bytes per sample
+    return header + pcm_data
+
+
+@pytest.fixture
+def raw_pcm_audio() -> bytes:
+    """Generate raw 16-bit PCM audio (no header)."""
+    return generate_sine_wave_pcm(duration_ms=100)
+
+
+@pytest.mark.skipif(not FFMPEG_AVAILABLE, reason="ffmpeg not installed")
+class TestConvertToOggOpus:
+    """Tests for convert_to_ogg_opus function."""
+
+    @pytest.mark.asyncio
+    async def test_convert_wav_to_ogg(self, wav_audio: bytes) -> None:
+        """Converting WAV to OGG should produce valid OGG output."""
+        result = await convert_to_ogg_opus(wav_audio, input_format="wav")
+
+        # OGG files start with "OggS"
+        assert result[:4] == b"OggS", "Output should be OGG format"
+        assert len(result) > 0
+
+    @pytest.mark.asyncio
+    async def test_convert_raw_pcm_to_ogg(self, raw_pcm_audio: bytes) -> None:
+        """Converting raw PCM to OGG should work with sample_rate specified."""
+        result = await convert_to_ogg_opus(
+            raw_pcm_audio,
+            input_format="s16le",
+            sample_rate=24000,
+        )
+
+        assert result[:4] == b"OggS", "Output should be OGG format"
+        assert len(result) > 0
+
+    @pytest.mark.asyncio
+    async def test_raw_pcm_requires_sample_rate(self, raw_pcm_audio: bytes) -> None:
+        """Raw PCM conversion should fail without sample_rate."""
+        with pytest.raises(AudioConversionError, match="sample_rate required"):
+            await convert_to_ogg_opus(raw_pcm_audio, input_format="s16le")
+
+    @pytest.mark.asyncio
+    async def test_invalid_audio_fails(self) -> None:
+        """Invalid audio data should raise AudioConversionError."""
+        with pytest.raises(AudioConversionError):
+            await convert_to_ogg_opus(b"not audio data", input_format="wav")
+
+    @pytest.mark.asyncio
+    async def test_empty_audio_fails(self) -> None:
+        """Empty audio data should raise AudioConversionError."""
+        with pytest.raises(AudioConversionError):
+            await convert_to_ogg_opus(b"", input_format="wav")
+
+    @pytest.mark.asyncio
+    async def test_output_is_smaller_than_wav(self, wav_audio: bytes) -> None:
+        """OGG/Opus output should be smaller than WAV input (compression)."""
+        result = await convert_to_ogg_opus(wav_audio, input_format="wav")
+
+        # Opus is highly compressed, should be much smaller
+        # For very short audio, overhead might make it similar, but still check
+        assert len(result) < len(wav_audio) * 2, (
+            "Output should not be much larger than input"
+        )
+
+
+class TestAudioConversionErrorHandling:
+    """Tests for error handling when ffmpeg is not available."""
+
+    @pytest.mark.asyncio
+    async def test_ffmpeg_not_found(self, wav_audio: bytes, monkeypatch) -> None:
+        """Should raise AudioConversionError if ffmpeg is not found."""
+
+        async def mock_create_subprocess(*args, **kwargs):
+            raise FileNotFoundError("ffmpeg")
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", mock_create_subprocess)
+
+        with pytest.raises(AudioConversionError, match="ffmpeg not found"):
+            await convert_to_ogg_opus(wav_audio, input_format="wav")


### PR DESCRIPTION
## Summary

Converts TTS audio to OGG/Opus format so Telegram displays it as a playable voice message instead of an audio file attachment.

## Changes

### Docker
- Added `ffmpeg` to the runtime stage for audio conversion

### New: `derp/common/audio.py`
- `convert_to_ogg_opus()` - async audio conversion using ffmpeg subprocess
- Handles both WAV containers and raw 16-bit PCM (s16le) input
- Optimized for voice with `-application voip` Opus profile

### `derp/common/sender.py`
- Added `ContentBuilder.voice()` method for voice messages
- Voice messages sent via `bot.send_voice()` (plays inline in Telegram)
- Added `parse_mode="HTML"` for voice captions (consistency with other media)

### `derp/tools/gemini_tts.py`
- Converts Gemini TTS output (`audio/L16;rate=24000`) to OGG/Opus
- Uses `.voice()` instead of `.audio()` for proper voice message display
- Case-insensitive MIME type detection for L16/PCM formats

### Tests
- Added `tests/test_audio.py` with 7 tests for audio conversion
- Tests skipped if ffmpeg not available

## Data Flow

```
Gemini TTS → audio/L16 PCM → convert_to_ogg_opus() → OGG/Opus → send_voice() → Telegram
```

## Testing
- All 390 tests pass
- Manually tested TTS commands produce playable voice messages